### PR TITLE
DEV-209 - CodeBuild ECR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.env.deploy.yml
+.env.*.yml
+.idea
+

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
-docker build -t serverless:latest .
+docker build -t docker-serverless:latest .

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,15 +4,14 @@ phases:
   pre_build:
     commands:
       - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
-      - REPOSITORY_URI=173432075717.dkr.ecr.us-west-2.amazonaws.com/docker-serverless
+      - REPOSITORY_URI=${ECR_REPOSITORY_URI_PREFIX}serverless
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
       - ls -al ${CODEBUILD_SRC_DIR}
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
-      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+      - docker build --tag $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR} --tag $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:
       - docker push $REPOSITORY_URI:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
   build:
     commands:
       - ls -al ${CODEBUILD_SRC_DIR}
-      - . ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build docker_serverless_build
+      - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
       - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,7 @@ phases:
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
+      - cd ${CODEBUILD_SRC_DIR}
       - . get-env.sh docker_serverless_build
       - docker build -t $REPOSITORY_URI:latest .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
   build:
     commands:
       - ls -al ${CODEBUILD_SRC_DIR}
-      - (cd ${CODEBUILD_SRC_DIR}; . get-env.sh docker_serverless_build)
+      - (cd ${CODEBUILD_SRC_DIR}; . ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build)
       - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,16 +3,14 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
-      - REPOSITORY_URI=${ECR_REPOSITORY_URI_PREFIX}serverless
-      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - IMAGE_TAG=${COMMIT_HASH:=latest}
+      - COMMIT_HASH=$(git rev-parse --short HEAD)
+      - IMAGE_REPO_URI=${IMAGE_REPO_PREFIX}${IMAGE_REPO_NAME}
+      - $(aws ecr get-login --no-include-email)
   build:
     commands:
-      - ls -al ${CODEBUILD_SRC_DIR}
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build --tag $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR} --tag $REPOSITORY_URI:$IMAGE_TAG
+      - docker build ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:${COMMIT_HASH} --tag ${IMAGE_REPO_URI}:latest
   post_build:
     commands:
-      - docker push $REPOSITORY_URI:latest
-      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - docker push ${IMAGE_REPO_URI}:${COMMIT_HASH}
+      - docker push ${IMAGE_REPO_URI}:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,7 @@ phases:
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
+      - ls -al ${CODEBUILD_SRC_DIR}
       - (cd ${CODEBUILD_SRC_DIR}; . get-env.sh docker_serverless_build)
       - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - REPOSITORY_URI=173432075717.dkr.ecr.us-west-2.amazonaws.com/docker-serverless
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - . get-env.sh docker_serverless_build
+      - docker build -t $REPOSITORY_URI:latest .
+      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+  post_build:
+    commands:
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,9 +9,8 @@ phases:
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
-      - cd ${CODEBUILD_SRC_DIR}
-      - . get-env.sh docker_serverless_build
-      - docker build -t $REPOSITORY_URI:latest .
+      - . ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
+      - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
-      - . ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
+      - (cd ${CODEBUILD_SRC_DIR}; . get-env.sh docker_serverless_build)
       - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
   build:
     commands:
       - ls -al ${CODEBUILD_SRC_DIR}
-      - (cd ${CODEBUILD_SRC_DIR}; . ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build)
+      - . ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build docker_serverless_build
       - docker build -t $REPOSITORY_URI:latest ${CODEBUILD_SRC_DIR}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:


### PR DESCRIPTION
This PR is the second of a series designed to enhance our CodeBuild job performance.  Here we build a docker-serverless image and upload it to ECR.  A basic buildspec.yml has been introduced, and the image name is normalized to the repo name, which will be done in all other repositories.