### PR TITLE
DEV-209 - Add buildspec for CodeBuild, tag as both 'serverless' and '…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-.env.deploy.yml
+.env.*.yml
+.idea

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
-docker build -t serverless:latest .
+docker build -t serverless:latest -t docker-serverless:latest .

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - COMMIT_HASH=$(git rev-parse --short HEAD)
+      - IMAGE_REPO_URI=${IMAGE_REPO_PREFIX}${IMAGE_REPO_NAME}
+      - $(aws ecr get-login --no-include-email)
+  build:
+    commands:
+      - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
+      - docker build ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:${COMMIT_HASH} --tag ${IMAGE_REPO_URI}:latest
+  post_build:
+    commands:
+      - docker push ${IMAGE_REPO_URI}:${COMMIT_HASH}
+      - docker push ${IMAGE_REPO_URI}:latest


### PR DESCRIPTION
…docker-serverless' for compatibility with existing build process

We had broken builds in QA due to a change in the build script tagging in this repo.  We are now tagging both as legacy `serverless` and repo-matched `docker-serverless`.