### PR TITLE
adding datadog plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "serverless-python-requirements": "4.1.1",
-    "serverless-plugin-scripts": "^1.0.2"
+    "serverless-plugin-scripts": "1.0.2",
+    "serverless-plugin-datadog": "1.1.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
In order to use the serverless datadog plugin in serverless, it must be available within the build environment.
This change introduce the 1.x (allows minor version upgrades) in the serverless environment.