### PR TITLE
Fix deployed lambda functions not working due to setuptools monkeypatching

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,10 @@ if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then
     # we need to use sed to do this because not all functions are configured to use the env variables from the files
     # The hack here is that we assume that every file has a `core_cache` env var and we put the SETUPTOOLS_USE_DISTUTILS after
     # it
-    sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' src/serverless.yml
+    if [ -z "$SETUPTOOLS_USE_DISTUTILS" ]
+    then
+        sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' src/serverless.yml
+    fi
 
     echo "Merging .env.docker_serverless_build.yml and .env.project_generation.yml into .env.yml..."
     echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then
     echo "deploy__whoami: ${deploy__whoami:-unknown}" >> ${ENV_FILE}
     echo "deploy__branch: ${deploy__branch:-unknown}" >> ${ENV_FILE}
     echo "deploy__HEAD: ${deploy__HEAD:-unknown}" >> ${ENV_FILE}
+    echo "SETUPTOOLS_USE_DISTUTILS: ${SETUPTOOLS_USE_DISTUTILS:-stdlib}" >> ${ENV_FILE}
 
     echo "Merging .env.docker_serverless_build.yml and .env.project_generation.yml into .env.yml..."
     echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,8 @@ if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then
     # it
     if [ -z "$SETUPTOOLS_USE_DISTUTILS" ]
     then
-        sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' src/serverless.yml
+        echo "Adding SETUPTOOLS_USE_DISTUTILS var into serverless yml"
+        sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' serverless.yml
     fi
 
     echo "Merging .env.docker_serverless_build.yml and .env.project_generation.yml into .env.yml..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,11 @@ if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then
     # tools is coming from on lambda except that it is causing all newly deployed lambda functions to fail.
     # setting this env variable prevents the distutils being overwritten by this code here:
     # https://github.com/pypa/setuptools/blob/04e3df22df840c6bb244e9b27bc56750c44b7c85/_distutils_hack/__init__.py#L36
-    echo "SETUPTOOLS_USE_DISTUTILS: ${SETUPTOOLS_USE_DISTUTILS:-stdlib}" >> ${ENV_FILE}
+
+    # we need to use sed to do this because not all functions are configured to use the env variables from the files
+    # The hack here is that we assume that every file has a `core_cache` env var and we put the SETUPTOOLS_USE_DISTUTILS after
+    # it
+    sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' serverless.yml
 
     echo "Merging .env.docker_serverless_build.yml and .env.project_generation.yml into .env.yml..."
     echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,11 @@ if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then
     echo "deploy__whoami: ${deploy__whoami:-unknown}" >> ${ENV_FILE}
     echo "deploy__branch: ${deploy__branch:-unknown}" >> ${ENV_FILE}
     echo "deploy__HEAD: ${deploy__HEAD:-unknown}" >> ${ENV_FILE}
+    # NOTE (Vlad): This was added August 31st 2020 after setuptools suddenly stopped working
+    # due to the setuptools v50 upgrade. It's unclear at this time where the v50 of setup
+    # tools is coming from on lambda except that it is causing all newly deployed lambda functions to fail.
+    # setting this env variable prevents the distutils being overwritten by this code here:
+    # https://github.com/pypa/setuptools/blob/04e3df22df840c6bb244e9b27bc56750c44b7c85/_distutils_hack/__init__.py#L36
     echo "SETUPTOOLS_USE_DISTUTILS: ${SETUPTOOLS_USE_DISTUTILS:-stdlib}" >> ${ENV_FILE}
 
     echo "Merging .env.docker_serverless_build.yml and .env.project_generation.yml into .env.yml..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then
     # we need to use sed to do this because not all functions are configured to use the env variables from the files
     # The hack here is that we assume that every file has a `core_cache` env var and we put the SETUPTOOLS_USE_DISTUTILS after
     # it
-    sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' serverless.yml
+    sed -i '/core_cache:.*/a \ \ \ \ SETUPTOOLS_USE_DISTUTILS:\ stdlib' src/serverless.yml
 
     echo "Merging .env.docker_serverless_build.yml and .env.project_generation.yml into .env.yml..."
     echo


### PR DESCRIPTION
The issue has been affecting many people today

https://github.com/pypa/setuptools/issues/2350

This seems to be the fix to unblock us from deploying without having to modify a bunch of source files across repos. To override this value, a project can set this env var in its own buildspec.yml. 

Tested by deploying from local, will also test on live before merging