### PR TITLE
Install serverless-domain-manager, for custom domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "serverless-python-requirements": "4.1.1",
     "serverless-plugin-scripts": "1.0.2",
-    "serverless-plugin-datadog": "1.1.0"
+    "serverless-plugin-datadog": "1.1.0",
+    "serverless-domain-manager": "4.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Installing serverless-domain-manager to assist with setting up custom domains for API Gateway

https://github.com/amplify-education/serverless-domain-manager
https://www.serverless.com/blog/serverless-api-gateway-domain

This will be used on https://github.com/sleepio/client-gateway-service-cluster to resolve https://bighealth.atlassian.net/browse/DEV-321