### PR TITLE
Add serverless-plugin-log-subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "serverless-python-requirements": "4.1.1",
     "serverless-plugin-scripts": "1.0.2",
-    "serverless-plugin-datadog": "2.4.0"
+    "serverless-plugin-datadog": "2.4.0",
+    "serverless-plugin-log-subscription": "1.4.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Plugin to subscribe the cloudwatch log group to some destination.

Using this instead of the datadog plugin. The datadog plugin is too heavy-handed and messes with things we don't want it to mess with (and as of now, there is no way to finely control it to do exactly what we want).

https://www.serverless.com/plugins/serverless-plugin-log-subscription

Had a successful deploy with this: https://3msv6xt4xe.execute-api.us-west-2.amazonaws.com/dev/deploy/build?arn=arn:aws:codebuild:us-west-2:173432075717:build/user-service-cluster:bc8536de-2379-4457-a321-c5e7efb616ff