### PR TITLE
Build 1.70.0 and 2.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:alpine
 MAINTAINER Yannis Panousis <yannis@bighealth.com>
+
+# 1.70.1 broke role creation, so pin to 1.70 until resolved
+# https://github.com/serverless/serverless/pull/7357 changed names -> leak
+# https://github.com/serverless/serverless/pull/7694 changed back -> collision
+ARG SERVERLESS_VERSION=1.70.0
+
 RUN apk update
 RUN apk upgrade
 RUN apk add ca-certificates && update-ca-certificates
@@ -27,10 +33,7 @@ RUN rm /var/cache/apk/*
 WORKDIR /var/task
 
 RUN npm install -g try-thread-sleep
-# 1.70.1 broke role creation, so pin to 1.70 until resolved
-# https://github.com/serverless/serverless/pull/7357 changed names -> leak
-# https://github.com/serverless/serverless/pull/7694 changed back -> collision
-RUN npm install -g serverless@1.70.0 --ignore-scripts spawn-sync
+RUN npm install -g serverless@${SERVERLESS_VERSION} --ignore-scripts spawn-sync
 
 COPY . /var
 

--- a/build
+++ b/build
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
-docker build -t serverless:latest -t docker-serverless:latest .
+docker build --build-arg SERVERLESS_VERSION=1.70.0 -t serverless:latest -t docker-serverless:latest -t docker-serverless:1.70.0 .
+docker build --build-arg SERVERLESS_VERSION=2.13.0 -t docker-serverless:2.13.0 .

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,17 @@
 version: 0.2
 
+batch:
+  fast-fail: false
+  build-list:
+      - identifier: latest
+        env:
+          IMAGE_TAG: latest
+          SERVERLESS_VERSION: 1.70.0
+      - identifier: 2.13.0
+        env:
+          IMAGE_TAG: 2.13.0
+          SERVERLESS_VERSION: 2.13.0
+
 phases:
   pre_build:
     commands:
@@ -10,8 +22,8 @@ phases:
   build:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:${COMMIT_HASH} --tag ${IMAGE_REPO_URI}:latest
+      - docker build --build-arg SERVERLESS_VERSION=${SERVERLESS_VERSION} ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:${COMMIT_HASH} --tag ${IMAGE_REPO_URI}:${IMAGE_TAG}
   post_build:
     commands:
       - docker push ${IMAGE_REPO_URI}:${COMMIT_HASH}
-      - docker push ${IMAGE_REPO_URI}:latest
+      - docker push ${IMAGE_REPO_URI}:${IMAGE_TAG}

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,17 +1,5 @@
 version: 0.2
 
-batch:
-  fast-fail: false
-  build-list:
-      - identifier: latest
-        env:
-          IMAGE_TAG: latest
-          SERVERLESS_VERSION: 1.70.0
-      - identifier: 2.13.0
-        env:
-          IMAGE_TAG: 2.13.0
-          SERVERLESS_VERSION: 2.13.0
-
 phases:
   pre_build:
     commands:
@@ -22,8 +10,10 @@ phases:
   build:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build --build-arg SERVERLESS_VERSION=${SERVERLESS_VERSION} ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:${COMMIT_HASH} --tag ${IMAGE_REPO_URI}:${IMAGE_TAG}
+      - docker build --build-arg SERVERLESS_VERSION=1.70.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:1.70.0 --tag ${IMAGE_REPO_URI}:latest
+      - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
   post_build:
     commands:
-      - docker push ${IMAGE_REPO_URI}:${COMMIT_HASH}
-      - docker push ${IMAGE_REPO_URI}:${IMAGE_TAG}
+      - docker push ${IMAGE_REPO_URI}:1.70.0
+      - docker push ${IMAGE_REPO_URI}:latest
+      - docker push ${IMAGE_REPO_URI}:2.13.0

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,7 +5,7 @@ phases:
     commands:
       - COMMIT_HASH=$(git rev-parse --short HEAD)
       - IMAGE_REPO_URI=${IMAGE_REPO_PREFIX}${IMAGE_REPO_NAME}
-      - $(aws ecr get-login --no-include-email)
+      - docker login -u AWS -p $(aws ecr get-login-password) https://$(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com || $(aws ecr get-login --no-include-email)
       - docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD || true
   build:
     commands:

--- a/sentry-release.sh
+++ b/sentry-release.sh
@@ -1,0 +1,1 @@
+./node_modules/.bin/sentry-cli releases new "$CODEBUILD_RESOLVED_SOURCE_VERSION"

--- a/sentry-release.sh
+++ b/sentry-release.sh
@@ -1,1 +1,0 @@
-./node_modules/.bin/sentry-cli releases new "$CODEBUILD_RESOLVED_SOURCE_VERSION"


### PR DESCRIPTION
Build both 1.70.0 and 2.13.0.

1.70.0 does not work for recording api and I do not want to update all the things to use 2.13.0 with the likelihood of serverless blowing up on us in production

1.70.0 is still :latest, but also now :1.70.0 and 2.13.0 is :2.13.0
:{commit hash} tag isn't being created anymore as we didn't use it and it doesn't make sense anymore