### PR TITLE
Pin Node version to 15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:15.3.0-alpine
 MAINTAINER Yannis Panousis <yannis@bighealth.com>
 
 # 1.70.1 broke role creation, so pin to 1.70 until resolved


### PR DESCRIPTION
🧷  Node to 15.3
Serverless deploy was wiping a bunch of files in the deployment package. It's apparently related to a new Node version.
https://github.com/serverless/serverless/issues/8794