### PR TITLE
PG-1600: add serverless-provisioned-concurrency-autoscaling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "serverless-python-requirements": "4.1.1",
     "serverless-plugin-scripts": "1.0.2",
     "serverless-plugin-datadog": "2.4.0",
-    "serverless-plugin-log-subscription": "1.4.0"
+    "serverless-plugin-log-subscription": "1.4.0",
+    "serverless-provisioned-concurrency-autoscaling": "1.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
https://bighealth.atlassian.net/browse/PG-1600

This is necessary to autoscale our lambdas so we don't get cold starts.  

Optional reading: https://www.serverless.com/plugins/serverless-provisioned-concurrency-autoscaling

This has been tested in dev and it works