### PR TITLE
STREAM-437 - Create image with serverless-plugin-aws-alerts installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Yannis Panousis <yannis@bighealth.com>
 # https://github.com/serverless/serverless/pull/7694 changed back -> collision
 ARG SERVERLESS_VERSION=1.70.0
 
+# Set 1 for installing serverless-plugin-aws-alerts via npm
+ARG PLUGIN_AWS_ALERTS=0
+
 RUN apk update
 RUN apk upgrade
 RUN apk add ca-certificates && update-ca-certificates
@@ -38,6 +41,8 @@ RUN npm install -g serverless@${SERVERLESS_VERSION} --ignore-scripts spawn-sync
 COPY . /var
 
 RUN cd /var && npm install
+
+RUN [ "${PLUGIN_AWS_ALERTS}" = "1" ] && npm install -g serverless-plugin-aws-alerts || :
 
 ENV NODE_PATH=/var
 

--- a/build
+++ b/build
@@ -3,3 +3,4 @@
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
 docker build --build-arg SERVERLESS_VERSION=1.70.0 -t serverless:latest -t docker-serverless:latest -t docker-serverless:1.70.0 .
 docker build --build-arg SERVERLESS_VERSION=2.13.0 -t docker-serverless:2.13.0 .
+docker build --build-arg SERVERLESS_VERSION=2.13.0 --build-arg PLUGIN_AWS_ALERTS=1 -t docker-serverless:2.13.0-alerts .

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,8 +12,11 @@ phases:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
       - docker build --build-arg SERVERLESS_VERSION=1.70.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:1.70.0 --tag ${IMAGE_REPO_URI}:latest
       - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
+      - docker build --build-arg SERVERLESS_VERSION=2.13.0 --build-arg PLUGIN_AWS_ALERTS=1 -t docker-serverless:2.13.0-alerts .
+
   post_build:
     commands:
       - docker push ${IMAGE_REPO_URI}:1.70.0
       - docker push ${IMAGE_REPO_URI}:latest
       - docker push ${IMAGE_REPO_URI}:2.13.0
+      - docker push ${IMAGE_REPO_URI}:2.13.0-alerts


### PR DESCRIPTION
This PR creates a serverless image with the new dependency (https://www.serverless.com/plugins/serverless-plugin-aws-alerts) installed. The attempt is made to avoid affecting the existing images at all, in order to avoid potential blow up in production.

The need for the new dependency arose due to https://github.com/sleepio/flows-cli/pull/33 in the context of https://bighealth.atlassian.net/browse/STREAM-437, where we are adding baseline configuration for CloudWatch metrics alerts. 

I'd like to loop in the DevOps team to see if this approach is reasonable and supportable. 