### PR TITLE
STREAM-437 - Add serverless-plugin-aws-alerts as npm dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,13 @@ WORKDIR /var/task
 
 RUN npm install -g try-thread-sleep
 
-# NOTE (TS): Added retries to circumvent the issue discussed in
-# https://github.com/npm/cli/issues/3078.
+# NOTE (TS, April 11, 2022): Added retries to circumvent the socket timeout
+# issue on concurrent npm package downloads discussed in
+# https://github.com/npm/cli/issues/3078. The ticket is marked closed as of
+# writing of this comment, but the actual issue remains unresolved. Check back
+# on that ticket thread to see the status, and remove the retry after the
+# resolution. Also, see https://github.com/sleepio/docker-serverless/pull/30 for
+# more context.
 RUN for retry in `seq 1 ${NPM_MAX_RETRY}` ; do \
     if npm install -g serverless@${SERVERLESS_VERSION} --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 --ignore-scripts spawn-sync ; \
     then echo "Install serverless@${SERVERLESS_VERSION} successful" ; break ; \
@@ -54,7 +59,7 @@ RUN for retry in `seq 1 ${NPM_MAX_RETRY}` ; do \
 
 COPY . /var
 
-# See the note on `npm install` above.
+# See the note by TS on `npm install` above.
 RUN cd /var && \
     for retry in `seq 1 ${NPM_MAX_RETRY}` ; do \
     if npm install --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 ; \

--- a/README.md
+++ b/README.md
@@ -132,7 +132,3 @@ If you get the following error when deploying:
   Invoked function failed
 ```
 make sure the role created by CloudFormation (of format ``<ServiceName>-<stage>-us-west-2-lambdaRole``) has the ``SSMDynamicSettings`` permission attached to it. Attach, wait for ~10 min, and re-deploy.
-
-### Need for watching CodeBuild builds
-
-Due to an `npm` issue (https://github.com/npm/cli/issues/3078) , `npm install` needs to be retried until it is successful. since the loop is currently infinite, it is strongly advised that you watch the specific build in CodeBuild until it succeeds; it should usually finish within a couple iterations. If retries go on too long, manually stop the build and troubleshoot again.

--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ If you get the following error when deploying:
   Invoked function failed
 ```
 make sure the role created by CloudFormation (of format ``<ServiceName>-<stage>-us-west-2-lambdaRole``) has the ``SSMDynamicSettings`` permission attached to it. Attach, wait for ~10 min, and re-deploy.
+
+### Need for watching CodeBuild builds
+
+Due to an `npm` issue (https://github.com/npm/cli/issues/3078) , `npm install` needs to be retried until it is successful. since the loop is currently infinite, it is strongly advised that you watch the specific build in CodeBuild until it succeeds; it should usually finish within a couple iterations. If retries go on too long, manually stop the build and troubleshoot again.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "serverless-python-requirements": "4.1.1",
+    "serverless-plugin-aws-alerts": "1.7.4",
     "serverless-plugin-scripts": "1.0.2",
     "serverless-plugin-datadog": "2.4.0",
     "serverless-plugin-log-subscription": "1.4.0",


### PR DESCRIPTION
This PR adds `serverless-plugin-aws-alerts` plugin to the npm dependency, modifying the existing images.

The need for the new dependency arose due to https://github.com/sleepio/flows-cli/pull/33 in the context of https://bighealth.atlassian.net/browse/STREAM-437, where we are adding baseline configuration for CloudWatch metrics alerts.

This implementation may be preferred over https://github.com/sleepio/docker-serverless/pull/29, if adding the dependency causes no issues in production.