### PR TITLE
STREAM-1147 - Build & publish Serverless 3.34.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine3.17
 MAINTAINER Yannis Panousis <yannis@bighealth.com>
 
-ARG SERVERLESS_VERSION=2.13.0
+ARG SERVERLESS_VERSION=3.34.0
 
 RUN apk update
 RUN apk upgrade
@@ -33,7 +33,9 @@ RUN npm install -g try-thread-sleep
 
 COPY . /var
 
-RUN cd /var && npm install --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000
+RUN cd /var && \
+    sed -i "s/\"serverless\": .*,/\"serverless\": \"${SERVERLESS_VERSION}\",/g" package.json && \
+    npm install --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000
 
 # Serverless gets installed already by `npm install` with package.json, but this makes it available globally
 RUN npm install -g serverless@${SERVERLESS_VERSION} --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 --ignore-scripts spawn-sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ RUN rm /var/cache/apk/*
 WORKDIR /var/task
 
 RUN npm install -g try-thread-sleep
-RUN npm install -g serverless@${SERVERLESS_VERSION} --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 --ignore-scripts spawn-sync
 
 COPY . /var
 
 RUN cd /var && npm install --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000
+
+# Serverless gets installed already by `npm install` with package.json, but this makes it available globally
+RUN npm install -g serverless@${SERVERLESS_VERSION} --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 --ignore-scripts spawn-sync
 
 ENV NODE_PATH=/var
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.3.0-alpine
+FROM node:lts-alpine3.17
 MAINTAINER Yannis Panousis <yannis@bighealth.com>
 
 # 1.70.1 broke role creation, so pin to 1.70 until resolved

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
 FROM node:lts-alpine3.17
 MAINTAINER Yannis Panousis <yannis@bighealth.com>
 
-# 1.70.1 broke role creation, so pin to 1.70 until resolved
-# https://github.com/serverless/serverless/pull/7357 changed names -> leak
-# https://github.com/serverless/serverless/pull/7694 changed back -> collision
-ARG SERVERLESS_VERSION=1.70.0
-
-ARG NPM_MAX_RETRY=5
+ARG SERVERLESS_VERSION=2.13.0
 
 RUN apk update
 RUN apk upgrade
@@ -35,45 +30,11 @@ RUN rm /var/cache/apk/*
 WORKDIR /var/task
 
 RUN npm install -g try-thread-sleep
-
-# NOTE (TS, April 11, 2022): Added retries to circumvent the socket timeout
-# issue on concurrent npm package downloads discussed in
-# https://github.com/npm/cli/issues/3078. The ticket is marked closed as of
-# writing of this comment, but the actual issue remains unresolved. Check back
-# on that ticket thread to see the status, and remove the retry after the
-# resolution. Also, see https://github.com/sleepio/docker-serverless/pull/30 for
-# more context.
-RUN for retry in `seq 1 ${NPM_MAX_RETRY}` ; do \
-    if npm install -g serverless@${SERVERLESS_VERSION} --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 --ignore-scripts spawn-sync ; \
-    then echo "Install serverless@${SERVERLESS_VERSION} successful" ; break ; \
-    else \
-        echo "Install serverless@${SERVERLESS_VERSION} retry ${retry}/${NPM_MAX_RETRY}..." ; \
-        if [ "$retry" -eq "$NPM_MAX_RETRY" ]; then \
-            echo "= BEG serverless@${SERVERLESS_VERSION} install error log ====" ; \
-            cat /root/.npm/_logs/*-debug.log ; \
-            echo "= END serverless@${SERVERLESS_VERSION} install error log ====" ; \
-            exit 1 ; \
-        fi ; \
-    fi ; \
-    done
+RUN npm install -g serverless@${SERVERLESS_VERSION} --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 --ignore-scripts spawn-sync
 
 COPY . /var
 
-# See the note by TS on `npm install` above.
-RUN cd /var && \
-    for retry in `seq 1 ${NPM_MAX_RETRY}` ; do \
-    if npm install --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000 ; \
-    then echo "Install npm packages for ${SERVERLESS_VERSION} successful" ; break ; \
-    else \
-        echo "Install npm packages for ${SERVERLESS_VERSION} retry ${retry}/${NPM_MAX_RETRY}..." ; \
-        if [ "$retry" -eq "$NPM_MAX_RETRY" ]; then \
-            echo "= BEG npm packages for ${SERVERLESS_VERSION} install error log ====" ; \
-            cat /root/.npm/_logs/*-debug.log ; \
-            echo "= END npm packages for ${SERVERLESS_VERSION} install error log ====" ; \
-            exit 1 ; \
-        fi ; \
-    fi ; \
-    done
+RUN cd /var && npm install --registry=https://registry.npmjs.org --prefer-offline=true --fetch-retries=5 --fetch-timeout=600000
 
 ENV NODE_PATH=/var
 

--- a/build
+++ b/build
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
-docker build --build-arg SERVERLESS_VERSION=2.13.0 -t docker-serverless:2.13.0 .
-docker build --build-arg SERVERLESS_VERSION=2.72.4 -t docker-serverless:2.72.4 .
+docker build --build-arg SERVERLESS_VERSION=3.34.0 -t docker-serverless:3.34.0 .
 

--- a/build
+++ b/build
@@ -3,3 +3,5 @@
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
 docker build --build-arg SERVERLESS_VERSION=1.70.0 -t serverless:latest -t docker-serverless:latest -t docker-serverless:1.70.0 .
 docker build --build-arg SERVERLESS_VERSION=2.13.0 -t docker-serverless:2.13.0 .
+docker build --build-arg SERVERLESS_VERSION=2.72.4 -t docker-serverless:2.72.4 .
+

--- a/build
+++ b/build
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 [ -e get-env.sh ] && . get-env.sh docker_serverless_build
-docker build --build-arg SERVERLESS_VERSION=1.70.0 -t serverless:latest -t docker-serverless:latest -t docker-serverless:1.70.0 .
 docker build --build-arg SERVERLESS_VERSION=2.13.0 -t docker-serverless:2.13.0 .
 docker build --build-arg SERVERLESS_VERSION=2.72.4 -t docker-serverless:2.72.4 .
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,10 +10,7 @@ phases:
   build:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build --build-arg SERVERLESS_VERSION=1.70.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:1.70.0 --tag ${IMAGE_REPO_URI}:latest
-      - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
+      - docker build --build-arg SERVERLESS_VERSION=2.72.4 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.72.4
   post_build:
     commands:
-      - docker push ${IMAGE_REPO_URI}:1.70.0
-      - docker push ${IMAGE_REPO_URI}:latest
-      - docker push ${IMAGE_REPO_URI}:2.13.0
+      - docker push ${IMAGE_REPO_URI}:2.72.4

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,12 @@ phases:
   build:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build --build-arg SERVERLESS_VERSION=2.72.4 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.72.4
+      - docker build --build-arg SERVERLESS_VERSION=1.70.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:1.70.0
+      - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
+      - docker build --build-arg SERVERLESS_VERSION=2.72.4 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.72.4 --tag ${IMAGE_REPO_URI}:latest
   post_build:
     commands:
+      - docker push ${IMAGE_REPO_URI}:1.70.0
+      - docker push ${IMAGE_REPO_URI}:2.13.0
       - docker push ${IMAGE_REPO_URI}:2.72.4
+      - docker push ${IMAGE_REPO_URI}:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,12 +10,10 @@ phases:
   build:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build --build-arg SERVERLESS_VERSION=1.70.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:1.70.0
       - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
       - docker build --build-arg SERVERLESS_VERSION=2.72.4 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.72.4 --tag ${IMAGE_REPO_URI}:latest
   post_build:
     commands:
-      - docker push ${IMAGE_REPO_URI}:1.70.0
       - docker push ${IMAGE_REPO_URI}:2.13.0
       - docker push ${IMAGE_REPO_URI}:2.72.4
       - docker push ${IMAGE_REPO_URI}:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,9 +11,9 @@ phases:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
       - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
-      - docker build --build-arg SERVERLESS_VERSION=2.72.4 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.72.4 --tag ${IMAGE_REPO_URI}:latest
+      - docker build --build-arg SERVERLESS_VERSION=3.34.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:3.34.0 --tag ${IMAGE_REPO_URI}:latest
   post_build:
     commands:
       - docker push ${IMAGE_REPO_URI}:2.13.0
-      - docker push ${IMAGE_REPO_URI}:2.72.4
+      - docker push ${IMAGE_REPO_URI}:3.34.0
       - docker push ${IMAGE_REPO_URI}:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,10 +10,8 @@ phases:
   build:
     commands:
       - ${CODEBUILD_SRC_DIR}/get-env.sh docker_serverless_build
-      - docker build --build-arg SERVERLESS_VERSION=2.13.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:2.13.0
       - docker build --build-arg SERVERLESS_VERSION=3.34.0 ${CODEBUILD_SRC_DIR} --tag ${IMAGE_REPO_URI}:3.34.0 --tag ${IMAGE_REPO_URI}:latest
   post_build:
     commands:
-      - docker push ${IMAGE_REPO_URI}:2.13.0
       - docker push ${IMAGE_REPO_URI}:3.34.0
       - docker push ${IMAGE_REPO_URI}:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,11 +10,11 @@ sed -i "s|\${bindPath}:|${SERVICE_PATH}:|g" /var/node_modules/serverless-python-
 sed -i -E "s/if \(options.dockerSsh\)/cmdOptions.push('-e', 'GIT_TOKEN=${GIT_TOKEN}'); if \(options.dockerSsh\)/g" /var/node_modules/serverless-python-requirements/lib/pip.js
 
 # Set the Lambda function runtime for custom-resource-existing-s3 to the desired NodeJS version
-S3_EXISTING_RESOURCE_NODEJS_VERSION="nodejs18.x"
-S3_EXISTING_RESOURCE_INDEX_JS="/var/node_modules/serverless/lib/plugins/aws/customResources/index.js"
-if [ -f ${S3_EXISTING_RESOURCE_INDEX_JS} ]; then
-    sed -i -E "s/Runtime: 'nodejs[0-9]+.x'/Runtime: '${S3_EXISTING_RESOURCE_NODEJS_VERSION}'/g" ${S3_EXISTING_RESOURCE_INDEX_JS}
-fi
+# S3_EXISTING_RESOURCE_NODEJS_VERSION="nodejs18.x"
+# S3_EXISTING_RESOURCE_INDEX_JS="/var/node_modules/serverless/lib/plugins/aws/customResources/index.js"
+# if [ -f ${S3_EXISTING_RESOURCE_INDEX_JS} ]; then
+#     sed -i -E "s/Runtime: 'nodejs[0-9]+.x'/Runtime: '${S3_EXISTING_RESOURCE_NODEJS_VERSION}'/g" ${S3_EXISTING_RESOURCE_INDEX_JS}
+# fi
 
 if [[ $@ = *"--no-publish"* ]]; then export NO_PUBLISH=true; else export NO_PUBLISH=false; fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,6 @@ PROJECT_GENERATION_ENV_FILE="/var/task/.env.project_generation.yml"
 
 # Set the required Docker mount path in order to run the in-Docker `pip install` 
 sed -i "s|\${bindPath}:|${SERVICE_PATH}:|g" /var/node_modules/serverless-python-requirements/lib/pip.js
-# Supply the GIT_TOKEN env var for the in-Docker `pip install`
-sed -i -E "s/if \(options.dockerSsh\)/cmdOptions.push('-e', 'GIT_TOKEN=${GIT_TOKEN}'); if \(options.dockerSsh\)/g" /var/node_modules/serverless-python-requirements/lib/pip.js
 
 if [[ $@ = *"--no-publish"* ]]; then export NO_PUBLISH=true; else export NO_PUBLISH=false; fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,8 +11,10 @@ sed -i -E "s/if \(options.dockerSsh\)/cmdOptions.push('-e', 'GIT_TOKEN=${GIT_TOK
 
 # Set the Lambda function runtime for custom-resource-existing-s3 to the desired NodeJS version
 S3_EXISTING_RESOURCE_NODEJS_VERSION="nodejs18.x"
-S3_EXISTING_RESOURCE_INDEX_JS="serverless/lib/plugins/aws/customResources/index.js"
-sed -i -E "s/Runtime: 'nodejs[0-9]+.x'/Runtime: '${S3_EXISTING_RESOURCE_NODEJS_VERSION}'/g" /var/node_modules/${S3_EXISTING_RESOURCE_INDEX_JS}
+S3_EXISTING_RESOURCE_INDEX_JS="/var/node_modules/serverless/lib/plugins/aws/customResources/index.js"
+if [ -f ${S3_EXISTING_RESOURCE_INDEX_JS} ]; then
+    sed -i -E "s/Runtime: 'nodejs[0-9]+.x'/Runtime: '${S3_EXISTING_RESOURCE_NODEJS_VERSION}'/g" ${S3_EXISTING_RESOURCE_INDEX_JS}
+fi
 
 if [[ $@ = *"--no-publish"* ]]; then export NO_PUBLISH=true; else export NO_PUBLISH=false; fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,15 @@ ENV_FILE="/var/task/.env.yml"
 DOCKER_SERVERLESS_BUILD_ENV_FILE="/var/.env.docker_serverless_build.yml"
 PROJECT_GENERATION_ENV_FILE="/var/task/.env.project_generation.yml"
 
+# Set the required Docker mount path in order to run the in-Docker `pip install` 
 sed -i "s|\${bindPath}:|${SERVICE_PATH}:|g" /var/node_modules/serverless-python-requirements/lib/pip.js
+# Supply the GIT_TOKEN env var for the in-Docker `pip install`
 sed -i -E "s/if \(options.dockerSsh\)/cmdOptions.push('-e', 'GIT_TOKEN=${GIT_TOKEN}'); if \(options.dockerSsh\)/g" /var/node_modules/serverless-python-requirements/lib/pip.js
+
+# Set the Lambda function runtime for custom-resource-existing-s3 to the desired NodeJS version
+S3_EXISTING_RESOURCE_NODEJS_VERSION="nodejs18.x"
+S3_EXISTING_RESOURCE_INDEX_JS="serverless/lib/plugins/aws/customResources/index.js"
+sed -i -E "s/Runtime: 'nodejs[0-9]+.x'/Runtime: '${S3_EXISTING_RESOURCE_NODEJS_VERSION}'/g" /var/node_modules/${S3_EXISTING_RESOURCE_INDEX_JS}
 
 if [[ $@ = *"--no-publish"* ]]; then export NO_PUBLISH=true; else export NO_PUBLISH=false; fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,13 +9,6 @@ sed -i "s|\${bindPath}:|${SERVICE_PATH}:|g" /var/node_modules/serverless-python-
 # Supply the GIT_TOKEN env var for the in-Docker `pip install`
 sed -i -E "s/if \(options.dockerSsh\)/cmdOptions.push('-e', 'GIT_TOKEN=${GIT_TOKEN}'); if \(options.dockerSsh\)/g" /var/node_modules/serverless-python-requirements/lib/pip.js
 
-# Set the Lambda function runtime for custom-resource-existing-s3 to the desired NodeJS version
-# S3_EXISTING_RESOURCE_NODEJS_VERSION="nodejs18.x"
-# S3_EXISTING_RESOURCE_INDEX_JS="/var/node_modules/serverless/lib/plugins/aws/customResources/index.js"
-# if [ -f ${S3_EXISTING_RESOURCE_INDEX_JS} ]; then
-#     sed -i -E "s/Runtime: 'nodejs[0-9]+.x'/Runtime: '${S3_EXISTING_RESOURCE_NODEJS_VERSION}'/g" ${S3_EXISTING_RESOURCE_INDEX_JS}
-# fi
-
 if [[ $@ = *"--no-publish"* ]]; then export NO_PUBLISH=true; else export NO_PUBLISH=false; fi
 
 if [[ ! $@ = *"--no-env"* ]] && [ $1 = "deploy" ]; then

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
-  "name": "serverless-project",
-  "version": "1.0.0",
+  "name": "docker-serverless",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "serverless-python-requirements": "4.1.1",
-    "serverless-plugin-aws-alerts": "1.7.4",
+    "serverless-python-requirements": "5.4.0",
+    "serverless-plugin-aws-alerts": "1.7.5",
     "serverless-plugin-scripts": "1.0.2",
-    "serverless-plugin-datadog": "2.4.0",
-    "serverless-plugin-log-subscription": "1.4.0",
-    "serverless-provisioned-concurrency-autoscaling": "1.2.0"
+    "serverless-plugin-datadog": "2.34.1",
+    "serverless-plugin-log-subscription": "2.2.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "serverless": "3.34.0",
+    "serverless": null,
     "serverless-python-requirements": "5.4.0",
     "serverless-plugin-aws-alerts": "1.7.5",
     "serverless-plugin-scripts": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "serverless": "3.34.0",
     "serverless-python-requirements": "5.4.0",
     "serverless-plugin-aws-alerts": "1.7.5",
     "serverless-plugin-scripts": "1.0.2",


### PR DESCRIPTION
**Context**

As part of [STREAM-1147](https://bighealth.atlassian.net/browse/STREAM-1147) we need to upgrade to Serverless 3.x in order to address critical security vulnerabilities.

**Changes made**

- [x] Build and publish Serverless Framework 3.34.0
- [x] Remove unused 1.70.0 build/publish
- [x] Upgrade Serverless plugin packages in `package.json`
- [x] Remove no longer needed hack to provide `GIT_TOKEN`

## Test plan

Shared test plan & execution with https://github.com/sleepio/streamtrace-flows/pull/660 and is described on that PR description.

[STREAM-1147]: https://bighealth.atlassian.net/browse/STREAM-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ